### PR TITLE
Remove extra quote character at the end of ProjectDir

### DIFF
--- a/sources/BamButz.MSBuild.TailwindCSS/Targets/BamButz.MSBuild.TailwindCSS.targets
+++ b/sources/BamButz.MSBuild.TailwindCSS/Targets/BamButz.MSBuild.TailwindCSS.targets
@@ -7,7 +7,7 @@
         <CallTarget Targets="CheckIfNodeJSIsInstalled" />
         <CallTarget Targets="InstallTailwindCSS" />
 
-        <Exec Command="node $(MSBuildThisFileDirectory)../index.js &quot;@(TailwindCSS->'%(FullPath)')&quot; &quot;@(TailwindCSS->'%(RootDir)%(Directory)%(Filename).min.css')&quot; &quot;$(ProjectDir)&quot;"
+        <Exec Command="node $(MSBuildThisFileDirectory)../index.js &quot;@(TailwindCSS->'%(FullPath)')&quot; &quot;@(TailwindCSS->'%(RootDir)%(Directory)%(Filename).min.css')&quot; &quot;$(ProjectDir)"
               WorkingDirectory="$(MSBuildThisFileDirectory)../" />
     </Target>
 


### PR DESCRIPTION
configs.js fails to load on Windows with this charachter